### PR TITLE
Add missing nmap package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.9
+RUN apt update && apt install -y nmap
 ADD . /code
 WORKDIR /code
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Added missing nmap package to fix the exception below:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/code/lib/check/ports.py", line 63, in check_ports
    data = await run(params)
  File "/code/lib/nmapquery.py", line 22, in run
    raise Exception('Nmap not installed in system')
Exception: Nmap not installed in system
```


