### PR TITLE
Added -Pn parameter

### DIFF
--- a/lib/check/ports.py
+++ b/lib/check/ports.py
@@ -54,6 +54,7 @@ async def check_ports(
             # while the higher-numbered ones are rarely useful.
             # default = 7
             '-oX',
+            '-Pn',
             '-',
             f"-p {','.join(map(str, check_ports))}",
             address


### PR DESCRIPTION
As not all hosts are pingable, we should not try to ping first hence the addition of the `-Pn` parameter.
